### PR TITLE
Instrumentation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,10 +14,10 @@ Checks: >
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-macro-usage,
   misc-*,
   -misc-const-correctness,
   -misc-non-private-member-variables-in-classes,
-  # -misc-static-assert,
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-return-braced-init-list,
@@ -37,5 +37,7 @@ CheckOptions:
   - key: readability-else-after-return.WarnOnConditionVariables
     value: true
   - key: readability-else-after-return.WarnOnUnfixable
+    value: true
+  - key: cppcoreguidelines-avoid-non-const-global-variables.AllowInternalLinkage
     value: true
 ...

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,7 +26,8 @@
             "displayName": "Root configuration used by all other presets",
             "hidden": true,
             "cacheVariables": {
-                "CLANG_TIDY": "ON"
+              "CLANG_TIDY": "ON",
+              "AIRSHIP_INSTRUMENTATION":  "ON"
             },
             "inherits": [
                 "gen:ninja",

--- a/examples/falling_triangles/game.cpp
+++ b/examples/falling_triangles/game.cpp
@@ -10,11 +10,11 @@
 #include <string>
 #include <vector>
 
-#include "color.h"
-#include "input.h"
-#include "opengl/renderer.h"
-#include "utils.hpp"
-#include "window.h"
+#include "core/input.h"
+#include "core/utils.hpp"
+#include "core/window.h"
+#include "render/color.h"
+#include "render/opengl/renderer.h"
 
 constexpr float DOWN_VEL = 0.2f; // Screen space / second
 constexpr float HUE_ROTATION_SPEED = 8.0f; // Degrees / second

--- a/examples/falling_triangles/game.h
+++ b/examples/falling_triangles/game.h
@@ -1,12 +1,12 @@
 #include <memory>
 #include <vector>
 
-#include "color.h"
 #include "core/application.h"
-#include "input.h"
-#include "opengl/renderer.h"
-#include "utils.hpp"
-#include "window.h"
+#include "core/input.h"
+#include "core/utils.hpp"
+#include "core/window.h"
+#include "render/color.h"
+#include "render/opengl/renderer.h"
 
 using vec3 = Airship::Utils::Point<float, 3>;
 

--- a/examples/shapes/CMakeLists.txt
+++ b/examples/shapes/CMakeLists.txt
@@ -14,7 +14,5 @@ set(ShapesExampleHeaders
 )
 
 target_sources(ShapesExample PUBLIC ${ShapesExampleSources})
-target_sources(ShapesExample PUBLIC FILE_SET HEADERS
-    FILES ${ShapesExampleHeaders}
-)
+target_sources(ShapesExample PUBLIC ${ShapesExampleHeaders})
 

--- a/examples/shapes/game.h
+++ b/examples/shapes/game.h
@@ -3,8 +3,8 @@
 #include <vector>
 
 #include "core/application.h"
+#include "core/utils.hpp"
 #include "render/opengl/renderer.h"
-#include "utils.hpp"
 
 // clang-format off
 const char* const vertexShaderSource =

--- a/examples/snake/CMakeLists.txt
+++ b/examples/snake/CMakeLists.txt
@@ -6,8 +6,8 @@ target_link_libraries(SnakeExample
 )
 
 target_sources(SnakeExample PUBLIC main.cpp game.cpp)
-target_sources(SnakeExample PUBLIC FILE_SET HEADERS
-    FILES game.h snake.h grid.h tallies.h
+target_sources(SnakeExample PUBLIC
+    game.h snake.h grid.h tallies.h
 )
 
 # Copy assets to the build tree

--- a/examples/snake/addons.h
+++ b/examples/snake/addons.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/instrumentation.h"
 #include "opengl/renderer.h"
 
 inline float randomRange(float min, float max) {
@@ -98,6 +99,7 @@ public:
     }
 
     void draw(const Airship::Renderer& renderer, Airship::Pipeline* pipeline) {
+        PROFILE_FUNCTION();
         for (auto& it : m_Streams) {
             it.second->sync();
         }

--- a/examples/snake/game.cpp
+++ b/examples/snake/game.cpp
@@ -6,13 +6,13 @@
 #include <vector>
 
 #include "addons.h"
-#include "color.h"
+#include "core/input.h"
+#include "core/logging.h"
+#include "core/window.h"
 #include "grid.h"
-#include "input.h"
-#include "logging.h"
-#include "opengl/renderer.h"
+#include "render/color.h"
+#include "render/opengl/renderer.h"
 #include "snake.h"
-#include "window.h"
 
 #define UNUSED(x) ((void) x)
 

--- a/examples/snake/game.h
+++ b/examples/snake/game.h
@@ -5,6 +5,7 @@
 #include "addons.h"
 #include "color.h"
 #include "core/application.h"
+#include "core/instrumentation.h"
 #include "grid.h"
 #include "input.h"
 #include "logging.h"
@@ -36,6 +37,7 @@ public:
 
 private:
     void draw() {
+        PROFILE_FUNCTION();
         if (m_Renderer) {
             m_Renderer->clear();
             m_BGMesh.draw(*m_Renderer, m_BGPipeline.get());

--- a/examples/snake/game.h
+++ b/examples/snake/game.h
@@ -3,16 +3,16 @@
 #include <memory>
 
 #include "addons.h"
-#include "color.h"
 #include "core/application.h"
+#include "core/input.h"
 #include "core/instrumentation.h"
+#include "core/logging.h"
+#include "core/window.h"
 #include "grid.h"
-#include "input.h"
-#include "logging.h"
-#include "opengl/renderer.h"
+#include "render/color.h"
+#include "render/opengl/renderer.h"
 #include "snake.h"
 #include "tallies.h"
-#include "window.h"
 
 constexpr float GRID_DIMS = 50;
 constexpr float GRID_PADDING = 0.1f;

--- a/examples/snake/grid.h
+++ b/examples/snake/grid.h
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <functional>
 
-#include "utils.hpp"
+#include "core/utils.hpp"
 
 template <size_t N>
 using ivec = Airship::Utils::Point<int, N>;

--- a/examples/snake/snake.h
+++ b/examples/snake/snake.h
@@ -210,6 +210,7 @@ public:
     }
 
     void Update(ivec2 applePos) {
+        PROFILE_FUNCTION();
         const auto& headPos = HeadPos();
         const auto& nextPos = m_Grid->getCoord(headPos + toVec(m_MoveDir));
         if (IntersectsSelf(nextPos)) {

--- a/examples/snake/tallies.h
+++ b/examples/snake/tallies.h
@@ -4,9 +4,9 @@
 #include <vector>
 
 #include "addons.h"
-#include "color.h"
-#include "opengl/renderer.h"
-#include "utils.hpp"
+#include "core/utils.hpp"
+#include "render/color.h"
+#include "render/opengl/renderer.h"
 
 constexpr float TALLY_WIDTH = 0.015;
 constexpr float TALLY_GROUP_HMARGIN = 0.012;

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -2,10 +2,17 @@ add_library(AirshipCore)
 target_link_libraries(AirshipCore PUBLIC spdlog glfw AirshipRenderer AirshipCommonFlags)
 enable_clang_tidy(AirshipCore)
 
+option(AIRSHIP_INSTRUMENTATION "Enable instrumentation and trace logging" OFF)
+
+if (AIRSHIP_INSTRUMENTATION)
+    add_compile_definitions(AIRSHIP_INSTRUMENTATION)
+endif()
+
 set(AirshipCoreSources
     src/core/application.cpp
     src/core/event.cpp
     src/core/window.cpp
+    src/core/instrumentation.cpp
 )
 
 set(AirshipCoreHeaders
@@ -13,6 +20,7 @@ set(AirshipCoreHeaders
     include/core/convar.h
     include/core/event.h
     include/core/input.h
+    include/core/instrumentation.h
     include/core/logging.h
     include/core/utils.hpp
     include/core/window.h

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -35,10 +35,7 @@ target_include_directories(AirshipCore
 )
 
 target_sources(AirshipCore PRIVATE ${AirshipCoreSources})
-target_sources(AirshipCore PUBLIC FILE_SET HEADERS
-    BASE_DIRS include/core
-    FILES ${AirshipCoreHeaders}
-)
+target_sources(AirshipCore PUBLIC ${AirshipCoreHeaders})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/core
     FILES
         ${AirshipCoreSources}

--- a/lib/core/include/core/instrumentation.h
+++ b/lib/core/include/core/instrumentation.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+#define CONCAt2(a, b) a##b
+#define CONCAT2(a, b) CONCAt2(a, b)
+#define PROFILE_SCOPE(name) ::Airship::Profiling::ScopeTimer CONCAT2(profiler_, __COUNTER__)(name)
+#define PROFILE_FUNCTION() PROFILE_SCOPE(__FUNCTION__)
+
+namespace Airship::Profiling {
+
+struct ScopeTimer {
+public:
+    ScopeTimer(const char* name_) noexcept;
+    ~ScopeTimer() noexcept; // NOLINT(performance-trivially-destructible)
+
+private:
+    [[maybe_unused]] const char* name;
+};
+
+void dump([[maybe_unused]] const std::string& filename);
+
+} // namespace Airship::Profiling

--- a/lib/core/src/core/application.cpp
+++ b/lib/core/src/core/application.cpp
@@ -7,10 +7,10 @@
 #include <string>
 #include <utility>
 
+#include "core/input.h"
 #include "core/instrumentation.h"
+#include "core/logging.h"
 #include "core/window.h"
-#include "input.h"
-#include "logging.h"
 #include "opengl/renderer.h"
 
 namespace Airship {

--- a/lib/core/src/core/application.cpp
+++ b/lib/core/src/core/application.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 
+#include "core/instrumentation.h"
 #include "core/window.h"
 #include "input.h"
 #include "logging.h"
@@ -42,18 +43,24 @@ void Application::Run() {
     }
     OnStart();
     GameLoop();
+    Profiling::dump("temp_file");
 }
 
 void Application::GameLoop() {
+    PROFILE_FUNCTION();
     auto startTime = std::chrono::system_clock::now();
     while (!m_ShouldClose) {
+        PROFILE_SCOPE("frame");
         if (m_MainWindow) m_MainWindow->pollEvents();
         auto frameTime = std::chrono::system_clock::now() - startTime;
         startTime = std::chrono::system_clock::now();
         auto elapsed = std::chrono::duration<float>(frameTime).count();
         elapsed = std::min(elapsed, 0.1f); // Clamp to avoid large jumps
 
-        OnGameLoop(elapsed);
+        {
+            PROFILE_SCOPE("User game loop");
+            OnGameLoop(elapsed);
+        }
 
         // Show the rendered buffer
         if (m_MainWindow) {

--- a/lib/core/src/core/instrumentation.cpp
+++ b/lib/core/src/core/instrumentation.cpp
@@ -1,4 +1,4 @@
-#include "instrumentation.h"
+#include "core/instrumentation.h"
 
 #ifndef AIRSHIP_INSTRUMENTATION
 namespace Airship::Profiling {

--- a/lib/core/src/core/instrumentation.cpp
+++ b/lib/core/src/core/instrumentation.cpp
@@ -1,0 +1,152 @@
+#include "instrumentation.h"
+
+#ifndef AIRSHIP_INSTRUMENTATION
+namespace Airship::Profiling {
+ScopeTimer::ScopeTimer(const char* name_) noexcept : name(name_) {}
+ScopeTimer::~ScopeTimer() noexcept = default;
+void dump([[maybe_unused]] const std::string& filename) {}
+} // namespace Airship::Profiling
+#else
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Airship::Profiling {
+
+enum class TraceEventType : uint8_t {
+    start,
+    end
+};
+
+struct TraceEvent {
+    const char* name;
+    uint64_t timestamp;
+    TraceEventType type;
+};
+
+struct EventBuffer {
+    EventBuffer(uint32_t tid) : threadIndex(tid) {}
+    EventBuffer(const EventBuffer&) = delete;
+    EventBuffer(const EventBuffer&&) = delete;
+    EventBuffer& operator=(const EventBuffer&) = delete;
+    EventBuffer& operator=(const EventBuffer&&) = delete;
+
+    uint32_t threadIdx() const { return threadIndex; }
+    void emplace_back(const char* name, uint64_t timestamp, TraceEventType type) {
+        events.emplace_back(name, timestamp, type);
+    }
+    TraceEvent get(size_t i) const { return events[i]; }
+    size_t count() const { return publishedCount.load(std::memory_order_acquire); }
+    void updateCount() { publishedCount = events.size(); }
+
+private:
+    // TODO: vectors can reallocate at random - we should refactor to something
+    // we have more control over to avoid hiccups
+    std::vector<TraceEvent> events;
+    uint32_t threadIndex;
+    std::atomic<size_t> publishedCount = 0;
+};
+
+namespace {
+const thread_local uint32_t g_threadIndex = []() noexcept {
+    static std::atomic<uint32_t> threadIndex = 0;
+    return threadIndex.fetch_add(1, std::memory_order_relaxed);
+}();
+
+// Combine thread-local buffers into a globally-accessible variable
+std::mutex g_threadBufferMutex;
+std::vector<std::unique_ptr<EventBuffer>> g_allEventBuffers;
+
+EventBuffer& GetThreadBuffer() {
+    thread_local EventBuffer* buffer = nullptr;
+    if (buffer != nullptr) return *buffer;
+
+    // Now we're in normal function context - exceptions are legal
+    auto buf = std::make_unique<EventBuffer>(g_threadIndex);
+
+    {
+        std::lock_guard<std::mutex> lock(g_threadBufferMutex);
+        buffer = g_allEventBuffers.emplace_back(std::move(buf)).get();
+    }
+
+    return *buffer;
+}
+
+// Lock g_allEventBuffers long enough to copy out the pointers (safe in case we ever spawn+instrument new threads)
+// Within each buffer: avoid race conditions by:
+// 1. Only pushing into the vectors, never popping
+// 2. Periodically publish the size of the vector (to use instead of .size()), indicating which elements are fully
+// initialized
+std::vector<EventBuffer*> SnapshotEventBuffers() {
+    std::lock_guard lock(g_threadBufferMutex);
+
+    std::vector<EventBuffer*> out;
+    out.reserve(g_allEventBuffers.size());
+
+    for (const auto& p : g_allEventBuffers)
+        out.push_back(p.get());
+
+    return out;
+}
+
+void PushEvent(const char* name, TraceEventType type) noexcept {
+    // TODO: Add VS profiler integration
+    // TODO: Check overhead of std::chrono calls, and potentially use OS implementations
+    try {
+        auto now = std::chrono::steady_clock::now();
+        auto us = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+        EventBuffer& threadBuffer = GetThreadBuffer();
+        threadBuffer.emplace_back(name, us, type);
+
+        // Occasionally bump up the published count (every event for now)
+        threadBuffer.updateCount();
+    } catch (...) {
+        // Swallow the error. Worst case scenario, some trace event is never started/stopped. Big whoop.
+        (void) 0; // Satisfies bugprone-empty-catch clang-tidy warning
+    }
+}
+} // namespace
+
+ScopeTimer::ScopeTimer(const char* name_) noexcept : name(name_) {
+    PushEvent(name, TraceEventType::start);
+}
+
+ScopeTimer::~ScopeTimer() noexcept {
+    PushEvent(name, TraceEventType::end);
+}
+
+// Dump all existing events to a json file, formatted for chrome-tracing/perfetto.ui
+void dump(const std::string& filename) {
+    auto buffers = SnapshotEventBuffers();
+
+    std::ofstream out(filename);
+    out << "{\"traceEvents\":[\n";
+
+    for (auto* buf : buffers) {
+        uint32_t end = buf->count();
+
+        for (uint32_t i = 0; i < end; ++i) {
+            const TraceEvent& e = buf->get(i);
+
+            out << "{";
+            out << R"("name":")" << e.name << "\",";
+            out << R"("ph":")" << (e.type == TraceEventType::start ? "B" : "E") << "\",";
+            out << "\"ts\":" << e.timestamp << ",";
+            out << "\"pid\":0,";
+            out << "\"tid\":" << buf->threadIdx();
+            out << "},\n";
+        }
+    }
+
+    out << "{}]}";
+}
+#endif
+
+} // namespace Airship::Profiling

--- a/lib/core/src/core/window.cpp
+++ b/lib/core/src/core/window.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "GLFW/glfw3.h"
+#include "core/instrumentation.h"
 #include "input.h"
 #include "logging.h"
 #include "utils.hpp"
@@ -178,16 +179,19 @@ Utils::Point<int, 2> Window::GetSize() const {
 }
 
 void Window::swapBuffers() const {
+    PROFILE_FUNCTION();
     glfwSwapBuffers(m_Window);
     GLFW_CHECK();
 }
 
 bool Window::shouldClose() const {
+    PROFILE_FUNCTION();
     int ret = glfwWindowShouldClose(m_Window);
     GLFW_CHECK();
     return ret != 0;
 }
 void Window::pollEvents() const {
+    PROFILE_FUNCTION();
     glfwPollEvents();
     GLFW_CHECK();
 }

--- a/lib/core/src/core/window.cpp
+++ b/lib/core/src/core/window.cpp
@@ -1,13 +1,14 @@
-#include "window.h"
+
+#include "core/window.h"
 
 #include <cassert>
 #include <string>
 
 #include "GLFW/glfw3.h"
+#include "core/input.h"
 #include "core/instrumentation.h"
-#include "input.h"
-#include "logging.h"
-#include "utils.hpp"
+#include "core/logging.h"
+#include "core/utils.hpp"
 
 // NOLINTNEXTLINE
 #define GLFW_CHECK()                                                                                                   \

--- a/lib/render/include/render/opengl/renderer.h
+++ b/lib/render/include/render/opengl/renderer.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include "logging.h"
+#include "core/logging.h"
 #include "render/color.h"
 
 namespace Airship {

--- a/lib/render/src/render/opengl/renderer.cpp
+++ b/lib/render/src/render/opengl/renderer.cpp
@@ -217,6 +217,7 @@ Shader::Shader(ShaderType stype, const std::string& source) : m_ShaderID(glCreat
     int ok;
     glGetShaderiv(m_ShaderID, GL_COMPILE_STATUS, &ok);
     if (ok != GL_TRUE) {
+        [[maybe_unused]]
         std::string log = getCompileLog();
         SHIPLOG_ERROR(log);
     }
@@ -293,6 +294,7 @@ Pipeline::Pipeline(const Shader& vShader, const Shader& fShader, const std::vect
     int ok;
     glGetProgramiv(m_ProgramID, GL_LINK_STATUS, &ok);
     if (ok != GL_TRUE) {
+        [[maybe_unused]]
         std::string log = getLinkLog();
         SHIPLOG_ERROR(log);
     }

--- a/lib/render/src/render/opengl/renderer.cpp
+++ b/lib/render/src/render/opengl/renderer.cpp
@@ -14,6 +14,7 @@
 
 #include "GL/gl3w.h"
 #include "GL/glcorearb.h"
+#include "core/instrumentation.h"
 #include "core/logging.h"
 #include "render/color.h"
 
@@ -342,6 +343,7 @@ void Renderer::draw(const std::vector<Mesh>& meshes, const Pipeline& pipeline, b
 }
 
 void Renderer::draw(const Mesh& mesh, const Pipeline& pipeline, bool doClear) const {
+    PROFILE_FUNCTION();
     SHIPLOG_TRACE("Drawing mesh with {} vertices", mesh.vertexCount());
     if (doClear) clear();
     // TODO: Cache VAO per mesh/pipeline combo

--- a/tests/src/render/renderer.test.cpp
+++ b/tests/src/render/renderer.test.cpp
@@ -4,10 +4,10 @@
 #include <string>
 #include <vector>
 
+#include "core/utils.hpp"
 #include "core/window.h"
 #include "gtest/gtest.h"
 #include "test/common.h"
-#include "utils.hpp"
 
 TEST(Renderer, Init) {
     // Use Application code to handle getting a window

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -30,9 +30,8 @@ function(airship_test TARGET_NAME SOURCE_LIST)
                 "${SOURCE_LIST}"
                 ${PROJECT_SOURCE_DIR}/tests/src/test/common.cpp 
         )
-        target_sources(${TARGET_NAME} PUBLIC FILE_SET HEADERS
-            BASE_DIRS ${PROJECT_SOURCE_DIR}/tests/include/test
-            FILES ${PROJECT_SOURCE_DIR}/tests/include/test/common.h
+        target_sources(${TARGET_NAME} PUBLIC
+            ${PROJECT_SOURCE_DIR}/tests/include/test/common.h
         )
         source_group("" FILES ${SOURCE_LIST})
         source_group("Common" 


### PR DESCRIPTION
PR targets the snake branch, since I develop linearly. But this could arguably be separated into a separate feature branch targeting main instead.

Introduces a simple instrumentation implementation. We don't support multithreading yet, but it was designed to be threading-friendly. Obviously no way to test that yet (not that I added tests for any part of this feature), so there's a decent chance we'll need to refactor once we start using threads elsewhere.

Instrumentation can be added on the user side with `PROFILE_FUNCTION` or `PROFILE_SCOPE(name)` macros. Although these always resolve to stack objects (even when instrumentation is disabled), the optimizer should be able to completely optimize it away when instrumentation is disabled. Instrumentation is OFF by default, but ON for all presets.

Also changed how headers are included in the targets. The old FILE_SET HEADERS method add the directories to TARGET_INCLUDE_DIRECTORIES, meaning we can include the headers by name (e.g. "input.h" instead of "core/input.h"). Since this isn't what we want, I changed it to just include the sources raw.