### PR TITLE
Renderer Optimizations + Headless Improvements

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,7 +26,7 @@
             "displayName": "Root configuration used by all other presets",
             "hidden": true,
             "cacheVariables": {
-              "CLANG_TIDY": "ON",
+              "CLANG_TIDY": "OFF",
               "AIRSHIP_INSTRUMENTATION":  "ON"
             },
             "inherits": [

--- a/examples/falling_triangles/game.cpp
+++ b/examples/falling_triangles/game.cpp
@@ -118,12 +118,14 @@ void Game::CreatePipelines() {
             {.name = "Position", .location = 0, .format = Airship::ShaderDataType::Float3},
             {.name = "Color", .location = 1, .format = Airship::ShaderDataType::Float4},
         });
+    m_TriMaterial = std::make_unique<Airship::Material>(m_TriPipeline.get());
     m_BGPipeline = std::make_unique<Airship::Pipeline>(
         bgVertexShader, bgFragmentShader,
         std::vector<Airship::Pipeline::VertexAttributeDesc>{
             {.name = "Position", .location = 0, .format = Airship::ShaderDataType::Float3},
             {.name = "Hue", .location = 1, .format = Airship::ShaderDataType::Float},
         });
+    m_BGMaterial = std::make_unique<Airship::Material>(m_BGPipeline.get());
 }
 
 namespace {
@@ -260,8 +262,8 @@ void Game::OnGameLoop(float elapsed) {
 
     // Draw code
     m_BGPipeline->bind();
-    m_Renderer->draw(m_BGMesh, *m_BGPipeline);
+    m_Renderer->draw(m_BGMesh, *m_BGMaterial);
 
     m_TriPipeline->bind();
-    m_Renderer->draw(m_TriMesh, *m_TriPipeline, false);
+    m_Renderer->draw(m_TriMesh, *m_TriMaterial, false);
 }

--- a/examples/falling_triangles/game.cpp
+++ b/examples/falling_triangles/game.cpp
@@ -262,8 +262,8 @@ void Game::OnGameLoop(float elapsed) {
 
     // Draw code
     m_BGPipeline->bind();
-    m_Renderer->draw(m_BGMesh, *m_BGMaterial);
+    m_Renderer.draw(m_BGMesh, *m_BGMaterial);
 
     m_TriPipeline->bind();
-    m_Renderer->draw(m_TriMesh, *m_TriMaterial, false);
+    m_Renderer.draw(m_TriMesh, *m_TriMaterial, false);
 }

--- a/examples/falling_triangles/game.h
+++ b/examples/falling_triangles/game.h
@@ -30,6 +30,7 @@ private:
     // inert constructors plus a factory method from the platform to create/validate.
     // Then we can remove these unique pointers.
     std::unique_ptr<Airship::Pipeline> m_TriPipeline, m_BGPipeline;
+    std::unique_ptr<Airship::Material> m_TriMaterial, m_BGMaterial;
     std::unique_ptr<Airship::Buffer> m_TriBuffer, m_BGBuffer, m_BGHuesBuffer;
     Airship::Mesh m_TriMesh, m_BGMesh;
 

--- a/examples/shapes/game.h
+++ b/examples/shapes/game.h
@@ -78,7 +78,7 @@ protected:
     void OnGameLoop(float /*elapsed*/) override {
         // Draw code
         m_Pipeline->bind();
-        m_Renderer->draw(m_Meshes, *m_Material);
+        m_Renderer.draw(m_Meshes, *m_Material);
     }
 
     std::vector<Airship::Buffer> m_Buffers;

--- a/examples/shapes/game.h
+++ b/examples/shapes/game.h
@@ -35,6 +35,7 @@ protected:
             vertexShader, fragmentShader,
             std::vector<Airship::Pipeline::VertexAttributeDesc>{
                 {.name = "Position", .location = 0, .format = Airship::ShaderDataType::Float3}});
+        m_Material = std::make_unique<Airship::Material>(m_Pipeline.get());
     }
     void OnStart() override {
 
@@ -77,10 +78,11 @@ protected:
     void OnGameLoop(float /*elapsed*/) override {
         // Draw code
         m_Pipeline->bind();
-        m_Renderer->draw(m_Meshes, *m_Pipeline);
+        m_Renderer->draw(m_Meshes, *m_Material);
     }
 
     std::vector<Airship::Buffer> m_Buffers;
     std::vector<Airship::Mesh> m_Meshes;
     std::unique_ptr<Airship::Pipeline> m_Pipeline;
+    std::unique_ptr<Airship::Material> m_Material;
 };

--- a/examples/snake/addons.h
+++ b/examples/snake/addons.h
@@ -98,12 +98,12 @@ public:
         return *ptr;
     }
 
-    void draw(const Airship::Renderer& renderer, Airship::Pipeline* pipeline) {
+    void draw(const Airship::Renderer& renderer, const Airship::Material& mat) {
         PROFILE_FUNCTION();
         for (auto& it : m_Streams) {
             it.second->sync();
         }
-        renderer.draw(*this, *pipeline, false);
+        renderer.draw(*this, mat, false);
     }
 
 private:

--- a/examples/snake/game.cpp
+++ b/examples/snake/game.cpp
@@ -52,23 +52,14 @@ void Game::CreatePipelines() {
                                                          {"Position", 0, Airship::ShaderDataType::Float2},
                                                          {"Color", 1, Airship::ShaderDataType::Float4},
                                                      });
+    flatShadedMaterial = std::make_unique<Airship::Material>(m_Pipeline.get());
     // BG coloring pipeline - stored in text files
     auto bgVertShader = Airship::Shader::from_file(Airship::ShaderType::Vertex, "assets/grass.vert");
     auto bgFragShader = Airship::Shader::from_file(Airship::ShaderType::Fragment, "assets/grass.frag");
     m_BGPipeline = std::make_unique<Airship::Pipeline>(
         bgVertShader, bgFragShader,
         std::vector<Airship::Pipeline::VertexAttributeDesc>{{"Position", 0, Airship::ShaderDataType::Float2}});
-    m_BGPipeline->setUniformsCallback([&]() {
-        static const auto start_time = std::chrono::steady_clock::now();
-        const auto cur_time = std::chrono::steady_clock::now();
-        std::chrono::duration<float> duration = cur_time - start_time;
-        m_BGPipeline->setUniform("iTime", duration.count());
-        m_BGPipeline->setUniform("iTip", m_BladeTipColor);
-        if (m_Snake.IsAlive())
-            m_BGPipeline->setUniform("iMaxTipDeviation", 1.0f);
-        else
-            m_BGPipeline->setUniform("iMaxTipDeviation", 0.0f);
-    });
+    backgroundMaterial = std::make_unique<Airship::Material>(m_BGPipeline.get());
 }
 
 void Game::OnKeyPress(const Airship::Window& window, Airship::Input::Key key, int scancode,
@@ -174,13 +165,21 @@ void Game::OnStart() {
     applePos.x() = static_cast<int>(randomRange(0, static_cast<float>(m_Grid.GetBounds().x())));
     applePos.y() = static_cast<int>(randomRange(0, static_cast<float>(m_Grid.GetBounds().y())));
     m_Apple = std::make_unique<Apple>(applePos, &m_Grid, Airship::Colors::Red);
+
+    backgroundMaterial->SetUniform("iTip", m_BladeTipColor);
+    backgroundMaterial->SetUniform("iMaxTipDeviation", 1.0f);
 }
 
 void Game::OnGameLoop(float elapsed) {
+    static const auto start_time = std::chrono::steady_clock::now();
+    const auto cur_time = std::chrono::steady_clock::now();
+    std::chrono::duration<float> duration = cur_time - start_time;
+    backgroundMaterial->SetUniform("iTime", duration.count());
     if (!m_Snake.IsAlive()) {
         if (m_Renderer) {
             constexpr Airship::Color deathColor = {0.2f, 0.0f, 0.0f};
             m_BladeTipColor = Airship::Color::lerp(m_BladeTipColor, deathColor, 0.05f);
+            backgroundMaterial->SetUniform("iTip", m_BladeTipColor);
         }
         draw();
         return;
@@ -193,6 +192,9 @@ void Game::OnGameLoop(float elapsed) {
     m_TickTime = 0;
     SHIPLOG_DEBUG("Loop");
     m_Snake.Update(m_Apple->pos());
+    if (!m_Snake.IsAlive()) {
+        backgroundMaterial->SetUniform("iMaxTipDeviation", 0.0f);
+    }
     if (m_Snake.HeadPos() == m_Apple->pos()) {
         ivec2 applePos;
         applePos.x() = static_cast<int>(randomRange(0, static_cast<float>(m_Grid.GetBounds().x())));

--- a/examples/snake/game.cpp
+++ b/examples/snake/game.cpp
@@ -176,11 +176,9 @@ void Game::OnGameLoop(float elapsed) {
     std::chrono::duration<float> duration = cur_time - start_time;
     backgroundMaterial->SetUniform("iTime", duration.count());
     if (!m_Snake.IsAlive()) {
-        if (m_Renderer) {
-            constexpr Airship::Color deathColor = {0.2f, 0.0f, 0.0f};
-            m_BladeTipColor = Airship::Color::lerp(m_BladeTipColor, deathColor, 0.05f);
-            backgroundMaterial->SetUniform("iTip", m_BladeTipColor);
-        }
+        constexpr Airship::Color deathColor = {0.2f, 0.0f, 0.0f};
+        m_BladeTipColor = Airship::Color::lerp(m_BladeTipColor, deathColor, 0.05f);
+        backgroundMaterial->SetUniform("iTip", m_BladeTipColor);
         draw();
         return;
     }

--- a/examples/snake/game.h
+++ b/examples/snake/game.h
@@ -40,16 +40,18 @@ private:
         PROFILE_FUNCTION();
         if (m_Renderer) {
             m_Renderer->clear();
-            m_BGMesh.draw(*m_Renderer, m_BGPipeline.get());
-            m_GridMesh.draw(*m_Renderer, m_Pipeline.get());
-            m_Snake.draw(*m_Renderer, m_Pipeline.get());
-            m_Apple->draw(*m_Renderer, m_Pipeline.get());
-            m_Tallies.draw(*m_Renderer, *m_Pipeline);
+            m_BGMesh.draw(*m_Renderer, *backgroundMaterial);
+            m_GridMesh.draw(*m_Renderer, *flatShadedMaterial);
+            m_Snake.draw(*m_Renderer, *flatShadedMaterial);
+            m_Apple->draw(*m_Renderer, *flatShadedMaterial);
+            m_Tallies.draw(*m_Renderer, *flatShadedMaterial);
         }
     }
     void CreatePipelines();
     std::unique_ptr<Airship::Pipeline> m_Pipeline;
+    std::unique_ptr<Airship::Material> flatShadedMaterial;
     std::unique_ptr<Airship::Pipeline> m_BGPipeline;
+    std::unique_ptr<Airship::Material> backgroundMaterial;
     float m_TickTime = std::numeric_limits<float>::max();
     Grid<2> m_Grid;
     std::unique_ptr<Apple> m_Apple;

--- a/examples/snake/game.h
+++ b/examples/snake/game.h
@@ -38,14 +38,12 @@ public:
 private:
     void draw() {
         PROFILE_FUNCTION();
-        if (m_Renderer) {
-            m_Renderer->clear();
-            m_BGMesh.draw(*m_Renderer, *backgroundMaterial);
-            m_GridMesh.draw(*m_Renderer, *flatShadedMaterial);
-            m_Snake.draw(*m_Renderer, *flatShadedMaterial);
-            m_Apple->draw(*m_Renderer, *flatShadedMaterial);
-            m_Tallies.draw(*m_Renderer, *flatShadedMaterial);
-        }
+        m_Renderer.clear();
+        m_BGMesh.draw(m_Renderer, *backgroundMaterial);
+        m_GridMesh.draw(m_Renderer, *flatShadedMaterial);
+        m_Snake.draw(m_Renderer, *flatShadedMaterial);
+        m_Apple->draw(m_Renderer, *flatShadedMaterial);
+        m_Tallies.draw(m_Renderer, *flatShadedMaterial);
     }
     void CreatePipelines();
     std::unique_ptr<Airship::Pipeline> m_Pipeline;

--- a/examples/snake/snake.h
+++ b/examples/snake/snake.h
@@ -102,7 +102,7 @@ public:
         m_MeshData.setVertexCount(canonicalSquare.size());
     }
 
-    void draw(const Airship::Renderer& renderer, Airship::Pipeline* pipeline) { m_MeshData.draw(renderer, pipeline); }
+    void draw(const Airship::Renderer& renderer, const Airship::Material& mat) { m_MeshData.draw(renderer, mat); }
     ivec2 pos() const { return m_GridPos; }
 
 private:
@@ -131,6 +131,7 @@ public:
     }
 
     void draw(const Airship::Renderer& renderer, Airship::Pipeline* pipeline) { m_MeshData.draw(renderer, pipeline); }
+    void draw(const Airship::Renderer& renderer, const Airship::Material& mat) { m_MeshData.draw(renderer, mat); }
     ivec2 pos() const { return m_GridPos; }
     void SetPos(ivec2 gridPos) {
         m_GridPos = gridPos;
@@ -193,10 +194,10 @@ public:
     void SetDir(Direction dir) { m_MoveDir = dir; }
     [[nodiscard]] Direction GetDir() { return m_MoveDir; }
     void PopTail() { m_Cells.PopTail(); }
-    void draw(const Airship::Renderer& renderer, Airship::Pipeline* pipeline) {
+    void draw(const Airship::Renderer& renderer, const Airship::Material& mat) {
         for (int i = static_cast<int>(m_Cells.GetCount()) - 1; i >= 0; --i) {
             auto& cell = m_Cells.GetElem(i);
-            cell.draw(renderer, pipeline);
+            cell.draw(renderer, mat);
         }
     }
 

--- a/examples/snake/tallies.h
+++ b/examples/snake/tallies.h
@@ -71,7 +71,7 @@ public:
         m_Count++;
     }
     bool full() const { return m_Count == MAX_TALLIES; }
-    void draw(Airship::Renderer& renderer, Airship::Pipeline& pipeline) { m_MeshData.draw(renderer, &pipeline); }
+    void draw(Airship::Renderer& renderer, const Airship::Material& mat) { m_MeshData.draw(renderer, mat); }
 
 private:
     DynamicMesh m_MeshData;
@@ -92,9 +92,9 @@ public:
         }
         m_TallyGroups.back().increment();
     }
-    void draw(Airship::Renderer& renderer, Airship::Pipeline& pipeline) {
+    void draw(Airship::Renderer& renderer, const Airship::Material& mat) {
         for (auto& group : m_TallyGroups)
-            group.draw(renderer, pipeline);
+            group.draw(renderer, mat);
     }
 
 private:

--- a/lib/core/include/core/application.h
+++ b/lib/core/include/core/application.h
@@ -25,7 +25,7 @@ protected:
                             Input::KeyMods /*mods*/) {}
 
     bool m_ShouldClose = false;
-    std::unique_ptr<Renderer> m_Renderer;
+    Renderer m_Renderer;
 
     std::unique_ptr<Window> m_MainWindow;
     int m_Width = 800, m_Height = 600;

--- a/lib/core/include/core/utils.hpp
+++ b/lib/core/include/core/utils.hpp
@@ -5,6 +5,12 @@
 #include <cstddef>
 
 namespace Airship::Utils {
+
+// Based on boost::hash_combine
+inline size_t hash_combine(size_t seed, size_t value) {
+    return seed ^ (value + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
 template <typename value_type, std::size_t D>
 class Point {
 public:

--- a/lib/core/src/core/application.cpp
+++ b/lib/core/src/core/application.cpp
@@ -23,12 +23,12 @@ Application::Application(int width, int height, std::string title) :
     m_Width(width), m_Height(height), m_Title(std::move(title)) {}
 
 void Application::Run() {
+    Window::Init();
+    if (m_Width < 0 || m_Height < 0) SHIPLOG_ERROR("Creating a window with negative dimensions");
+    m_MainWindow = std::make_unique<Window>(m_Width, m_Height, m_Title, !m_ServerMode);
     if (!m_ServerMode) {
-        Window::Init();
-        if (m_Width < 0 || m_Height < 0) SHIPLOG_ERROR("Creating a window with negative dimensions");
-        m_MainWindow = std::make_unique<Window>(m_Width, m_Height, m_Title, true);
         m_MainWindow->setWindowResizeCallback([this](int width, int height) {
-            m_Renderer->resize(width, height);
+            m_Renderer.resize(width, height);
             m_Height = height;
             m_Width = width;
         });
@@ -36,11 +36,10 @@ void Application::Run() {
             [this](const Window& window, Input::Key key, int scancode, Input::KeyAction action, Input::KeyMods mods) {
                 OnKeyPress(window, key, scancode, action, mods);
             });
-
-        m_Renderer = std::make_unique<Renderer>();
-        m_Renderer->init();
-        m_Renderer->resize(m_Width, m_Height);
     }
+
+    m_Renderer.init();
+    m_Renderer.resize(m_Width, m_Height);
     OnStart();
     GameLoop();
     Profiling::dump("temp_file");

--- a/lib/render/include/render/opengl/renderer.h
+++ b/lib/render/include/render/opengl/renderer.h
@@ -103,9 +103,9 @@ struct UniformTraits<Color> {
 };
 
 class Pipeline {
+public:
     using program_id = unsigned int;
 
-public:
     // Abstraction on per-vertex shader variables, e.g.
     // layout (location = 0) in vec3 aPos
     struct VertexAttributeDesc {
@@ -129,6 +129,7 @@ public:
     void bind() const;
     [[nodiscard]] const std::vector<VertexAttributeDesc>& getVertexAttributes() const { return m_VertexAttribs; }
     [[nodiscard]] int GetUniformLocation(const std::string& name) const;
+    [[nodiscard]] program_id get() const { return m_ProgramID; }
 
 private:
     [[nodiscard]] std::string getLinkLog() const;

--- a/lib/render/include/render/opengl/renderer.h
+++ b/lib/render/include/render/opengl/renderer.h
@@ -25,10 +25,11 @@ struct Buffer {
     ~Buffer();
     [[nodiscard]] buffer_id get() const { return m_BufferID; }
     void bind() const;
-    void update(size_t bytes, const void* data) const;
+    void update(size_t bytes, const void* data);
 
 private:
     buffer_id m_BufferID;
+    size_t m_Size = 0;
 };
 
 enum class ShaderDataType : uint8_t {

--- a/lib/render/include/render/opengl/renderer.h
+++ b/lib/render/include/render/opengl/renderer.h
@@ -5,8 +5,10 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "core/logging.h"
@@ -83,39 +85,24 @@ private:
     shader_id m_ShaderID;
 };
 
-class Uniform {
-public:
-    Uniform(ShaderDataType format) : m_Format(format) {}
-    virtual ~Uniform() = default;
-
-    template <size_t N>
-    static void SetFloatVector(int program, const std::string& name, const float* val, size_t count = 1);
-
-protected:
-    ShaderDataType m_Format;
-};
-
 // Can be extended by the user to set uniforms from user-defined classes
 template <typename T>
 struct UniformTraits {};
 
 template <>
 struct UniformTraits<float> {
-    static void Set(int program, const std::string& name, float val) {
-        Uniform::SetFloatVector<1>(program, name, &val);
-    }
+    using UniformType = float;
+    static UniformType Convert(const float& val) { return val; }
 };
 
 template <>
 struct UniformTraits<Color> {
-    static void Set(int program, const std::string& name, const Color& val) {
-        std::array<float, 4> vals = {val.r, val.g, val.b, val.a};
-        Uniform::SetFloatVector<4>(program, name, vals.data());
-    }
+    using UniformType = Color;
+    static UniformType Convert(const Color& val) { return val; }
 };
+
 class Pipeline {
     using program_id = unsigned int;
-    using set_uniform_callback = std::function<void()>;
 
 public:
     // Abstraction on per-vertex shader variables, e.g.
@@ -140,20 +127,57 @@ public:
     ~Pipeline();
     void bind() const;
     [[nodiscard]] const std::vector<VertexAttributeDesc>& getVertexAttributes() const { return m_VertexAttribs; }
-
-    template <typename T>
-    void setUniform(const std::string& name, const T& val) {
-        UniformTraits<T>::Set(m_ProgramID, name, val);
-    }
-
-    void bindUniforms() const;
-    void setUniformsCallback(set_uniform_callback callback) { m_SetUniformCallback = std::move(callback); }
+    [[nodiscard]] int GetUniformLocation(const std::string& name) const;
 
 private:
     [[nodiscard]] std::string getLinkLog() const;
     program_id m_ProgramID = 0;
     std::vector<VertexAttributeDesc> m_VertexAttribs;
-    set_uniform_callback m_SetUniformCallback;
+};
+
+using UniformVariant = std::variant<float, Color>;
+
+template <typename T>
+inline ShaderDataType DeduceShaderType() {
+    if constexpr (std::is_same_v<T, float>) return ShaderDataType::Float;
+    if constexpr (std::is_same_v<T, Color>) return ShaderDataType::Float4;
+}
+
+struct UniformValue {
+    ShaderDataType type;
+    UniformVariant value;
+    bool dirty;
+};
+
+template <typename T>
+concept UniformCompatible = requires(const T& v) {
+    typename UniformTraits<T>::UniformType;
+    { UniformTraits<T>::Convert(v) };
+};
+
+class Material {
+public:
+    Material(const Pipeline* pipeline) : m_Pipeline(pipeline) {}
+
+    template <UniformCompatible T>
+    void SetUniform(const std::string& name, const T& value) {
+        using Traits = UniformTraits<T>;
+        using UType = typename Traits::UniformType;
+
+        UType converted = Traits::Convert(value);
+
+        auto& u = m_Uniforms[name];
+        u.type = DeduceShaderType<UType>();
+        u.value = converted;
+        u.dirty = true;
+    }
+
+    void Bind() const;
+    [[nodiscard]] const Pipeline& pipeline() const { return *m_Pipeline; }
+
+private:
+    const Pipeline* m_Pipeline;
+    std::unordered_map<std::string, UniformValue> m_Uniforms;
 };
 
 class Renderer {
@@ -163,11 +187,12 @@ public:
     void resize(int width, int height) const;
 
     void clear() const;
-    void draw(const std::vector<Mesh>& meshes, const Pipeline& pipeline, bool doClear = true) const;
-    void draw(const Mesh& meshes, const Pipeline& pipeline, bool doClear = true) const;
+    void draw(const std::vector<Mesh>& meshes, const Material& mat, bool doClear = true) const;
+    void draw(const Mesh& mesh, const Material& mat, bool doClear = true) const;
     void setClearColor(const RGBColor& color);
 
 private:
     Color m_ClearColor = Colors::Magenta;
 };
+
 } // namespace Airship

--- a/lib/render/src/render/opengl/renderer.cpp
+++ b/lib/render/src/render/opengl/renderer.cpp
@@ -167,15 +167,22 @@ void Buffer::bind() const {
     CHECK_GL_ERROR();
 }
 
-void Buffer::update(size_t bytes, const void* data) const {
+void Buffer::update(size_t bytes, const void* data) {
     // GL_STATIC_DRAW: Set data once, used many times.
     // TODO: Implement switching to GL_STREAM_DRAW or GL_DYNAMIC_DRAW
     SHIPLOG_TRACE("Updating buffer {} with {} bytes of data", m_BufferID, bytes);
     if (!glIsBuffer(m_BufferID)) {
         SHIPLOG_ERROR("Attempting to update invalid buffer {}", m_BufferID);
     };
+    if (bytes > m_Size) {
+        // Expand the buffer to fit the data
     glNamedBufferData(m_BufferID, static_cast<GLsizeiptr>(bytes), data, GL_STATIC_DRAW);
     CHECK_GL_ERROR();
+        m_Size = bytes;
+    } else {
+        glNamedBufferSubData(m_BufferID, 0, static_cast<GLsizeiptr>(bytes), data);
+        CHECK_GL_ERROR();
+}
 }
 
 VertexArray::VertexArray() {

--- a/lib/render/src/render/opengl/renderer.cpp
+++ b/lib/render/src/render/opengl/renderer.cpp
@@ -285,6 +285,8 @@ VertexArray::VertexArray(VertexArray&& other) noexcept : m_VertexArrayID(other.m
     other.m_VertexArrayID = GL_INVALID_VALUE;
 }
 
+// Requires an active OpenGL context, so we can't do this in the constructor. Instead, call this from the
+// application after creating the window -- even in headless mode, as we may to do offscreen rendering.
 void Renderer::init() {
     if (gl3wInit() != 0) {
         SHIPLOG_MAYDAY("Unable to initialize gl3w");

--- a/lib/render/src/render/opengl/renderer.cpp
+++ b/lib/render/src/render/opengl/renderer.cpp
@@ -78,11 +78,13 @@ VertexFormatInfo getVertexFormatInfo(ShaderDataType format) {
 }
 
 VertexArray setupVertexArrayBinding(const Mesh& mesh, const Pipeline& pipeline) {
+    PROFILE_FUNCTION();
     VertexArray vao;
     uint32_t nextBinding = 0;
     SHIPLOG_DEBUG("Setting up vertex input bindings - {} pipeline attributes", pipeline.getVertexAttributes().size());
 
     for (const auto& attr : pipeline.getVertexAttributes()) {
+        PROFILE_SCOPE("setup vertex attribute");
         const VertexAttributeStream* stream = mesh.getStream(attr.name);
         assert(stream && "Shader requires missing vertex attribute");
         assert(stream->format == attr.format);
@@ -132,6 +134,7 @@ constexpr GLenum toGL(ShaderType stype) {
 } // anonymous namespace
 
 void Mesh::draw() const {
+    PROFILE_FUNCTION();
     assert(m_VertexCount % 3 == 0);
     glDrawArrays(GL_TRIANGLES, 0, m_VertexCount);
     CHECK_GL_ERROR();
@@ -186,6 +189,7 @@ VertexArray::~VertexArray() {
 }
 
 void VertexArray::bind() const {
+    PROFILE_FUNCTION();
     glBindVertexArray(m_VertexArrayID);
     CHECK_GL_ERROR();
 }

--- a/tests/include/test/common.h
+++ b/tests/include/test/common.h
@@ -36,12 +36,10 @@ public:
     GameClass(int width, int height) : Airship::Application(width, height, "test app") {}
     GameClass() : GameClass(600, 800) {}
     [[nodiscard]] Airship::Window* GetWindow() const { return m_MainWindow.get(); }
-    [[nodiscard]] Airship::Renderer* GetRenderer() const { return m_Renderer.get(); }
+    [[nodiscard]] const Airship::Renderer& GetRenderer() const { return m_Renderer; }
 
 protected:
-    void OnStart() override {
-        if (m_Renderer) m_Renderer->setClearColor(Airship::Colors::CornflowerBlue);
-    }
+    void OnStart() override { m_Renderer.setClearColor(Airship::Colors::CornflowerBlue); }
     void OnGameLoop(float /*elapsed*/) override {
         m_ShouldClose = true; // Skip the game loop
     }

--- a/tests/src/core/application.test.cpp
+++ b/tests/src/core/application.test.cpp
@@ -14,5 +14,6 @@ TEST(Window, null) {
     Airship::Test::GameClass app2(true);
     app2.Run();
 
-    EXPECT_EQ(app2.GetWindow(), nullptr);
+    // Even in server mode, we should still have a window (for offscreen rendering)
+    EXPECT_NE(app2.GetWindow(), nullptr);
 }

--- a/tests/src/render/renderer.test.cpp
+++ b/tests/src/render/renderer.test.cpp
@@ -84,8 +84,7 @@ TEST(Renderer, Init) {
                                               .format = Airship::ShaderDataType::Float3});
     meshes[1].setVertexCount(static_cast<int>(verticesB.size()));
 
-    auto* renderer = app.GetRenderer();
-    ASSERT_NE(renderer, nullptr);
+    const auto& renderer = app.GetRenderer();
 
     // TODO: Pull into application?
     while (!window->shouldClose()) {
@@ -93,7 +92,7 @@ TEST(Renderer, Init) {
 
         // Draw code
         pipeline.bind();
-        renderer->draw(meshes, material);
+        renderer.draw(meshes, material);
 
         // Show the rendered buffer
         window->swapBuffers();

--- a/tests/src/render/renderer.test.cpp
+++ b/tests/src/render/renderer.test.cpp
@@ -50,6 +50,7 @@ TEST(Renderer, Init) {
                                    {{.name = "Position", .location = 0, .format = Airship::ShaderDataType::Float3}}));
     Airship::Pipeline pipeline(vertexShader, fragmentShader,
                                {{.name = "Position", .location = 0, .format = Airship::ShaderDataType::Float3}});
+    Airship::Material material(&pipeline);
 
     // Normalized device coordinates (NDC)
     // (-1,-1) lower-left corner, (1,1) upper-right
@@ -92,7 +93,7 @@ TEST(Renderer, Init) {
 
         // Draw code
         pipeline.bind();
-        renderer->draw(meshes, pipeline);
+        renderer->draw(meshes, material);
 
         // Show the rendered buffer
         window->swapBuffers();


### PR DESCRIPTION
PR is based on the instrumentation branch, and should be rebased after #20 is merged.

The main optimization in this PR is to cache VAOs using information from the combined mesh+material that defines it. If either is deleted, the cache entry is removed. This changes OpenGL calls (which can cause stuttering on Snake on windows) to unordered_map key creation/contain checks. This can almost certainly be improved further in the future if needed.

Secondly, the uniform system is revamped with the addition of the start of a Material abstraction. This system is created to be extendible via type traits, so you can define exactly how custom types are streamed to the GPU as uniforms. The uniform values are cached as std::variants, which helps simplify the interface for the developer but also can eventually be used to move a few more OpenGL calls out of the draw call (e.g. by caching the uniform location).

The third optimization is to server mode, which I'd still say is work-in-progress. This solidifies the concept a little more, but it's not quite where we can use it effectively yet. (in my opinion, we may need to wait until we get networking involved before we can really test out server mode). Some points:
- Whether in server mode or in client mode, we need a renderer and a frame buffer to draw to (in case we need offscreen rendering or compute shaders).
- With OpenGL/GLFW, the simplest way to get a frame buffer is to create a GLFW window. In server mode, it's just hidden.
- This is technically a renderer API detail, and could be hidden behind the renderer abstraction. For example:
  - Client mode (OpenGL + Vulkan): Window owned by application, drawn to by renderer
  - Server mode (Vulkan): Application has no window, renderer creates a VkFrameBuffer (or multiple) to draw to.
  - Server mode (OpenGL): Application has no window, but the renderer creates a hidden one to get access to a frame buffer.